### PR TITLE
Mod plugin.js to support edge case

### DIFF
--- a/lib/pigsty-moloch-plugin/plugin.js
+++ b/lib/pigsty-moloch-plugin/plugin.js
@@ -432,7 +432,7 @@ molochPlugin.prototype.post = function(data) {
 
   var updateSession = function(callback) {
     //  debug("update got", JSON.stringify(_results));
-    var _document = { script: "ctx._source.ta += ta", params: { ta: _results.tags } };
+    var _document = { script: "if (!ctx._source.containsKey(\"ta\")) { ctx._source.ta = ta } else { ctx._source.ta += ta }", params: { ta: _results.tags } };
     // do bulk here ???
     _this.Db.update(_this.Db.id2Index(_results.sessionID), "session", _results.sessionID, _document, function (err, result) {
       _results.saved = true;


### PR DESCRIPTION
Moloch sessions not yet affixed with any tags do not yet have a "ta"
Elasticsearch field to which pigsty-moloch tags can be applied. Check
for presence of "ta" field and create it as necessary before appending 
tags.
